### PR TITLE
Update code to @slack/client@4.8.0 and fix vulnerabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 config.js
 node_modules/**
 npm-debug.log
+package-lock.json
 

--- a/config.js.example
+++ b/config.js.example
@@ -1,6 +1,6 @@
 /* vim: set ft=javascript ts=2 et sw=2 tw=80: */
-var JiraResponder = require("./jira");
-var rabbitmqresponder = require("./rabbitmq");
+var JiraResponder = require('./jira');
+var rabbitmqresponder = require('./rabbitmq');
 
 var config = {
   slack_api_token: 'xxxx-xxxxxxxxx-xxx',
@@ -12,12 +12,11 @@ var config = {
   ],
 
   schedules: [
-    { cron: "0 10 * * *", channel: "#bots", message: "This is a scheduled message at 10am <http://www.google.co.uk/|check google>!" },
-    { cron: "0 9 * * *", channel: "#bots", message: "This is a scheduled message at 9am" }
+    { cron: '0 10 * * *', channel: '#bots', message: 'This is a scheduled message at 10am <http://www.google.co.uk/|check google>!' },
+    { cron: '0 9 * * *', channel: '#bots', message: 'This is a scheduled message at 9am' }
   ],
 
   build: function (id) {
-
     // Jira integration
     var jiraConfig = {
       protocol: 'http',

--- a/package.json
+++ b/package.json
@@ -5,18 +5,19 @@
   "repository": "https://github.com/sjmelia/regexbot",
   "main": "src/index.js",
   "dependencies": {
-    "@slack/client": "^3.5.0",
+    "@slack/client": "^4.8.0",
     "jira-client": "^4.2.0",
     "node-schedule": "^1.2.0"
   },
   "devDependencies": {
+    "@slack/events-api": "^2.1.1",
     "chai": "^3.5.0",
-    "coveralls": "^2.11.9",
+    "coveralls": "^3.0.2",
     "eslint": "^2.13.1",
     "eslint-config-standard": "^5.3.1",
     "eslint-plugin-promise": "^1.3.2",
     "eslint-plugin-standard": "^1.3.2",
-    "mocha": "^2.5.3",
+    "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.2.0"
   },
   "scripts": {


### PR DESCRIPTION
When I did `npm install` for the current HEAD of the master branch, there were 15 or so vulnerabilities, one of which required updating the slack client to a new major version. I have updated the code to work with the new slack client version.

I also updated the dev dependencies that had vulnerabilities.

I ran the mocha tests and they all passed, and ESLint is happy.

I also ran a very quick test with my own Slack workspace, and the RTM client does appear to detect incoming messages.

Please merge this as soon as possible, as I plan to update the repo to include support for the Events API (rather than RTM, for example when using free dynos on Heroku), and I would like to base it on the up-to-date fork.