### PR TITLE
Add support for Slack Events API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ matches - `[0]` for the whole string, `[1]` for the first match, and so on.
 An example function is given for Jira, taking a config object. This function will connect to Jira, 
 retrieve the message summary for the given case (if found) and respond with a nicely formatted message/link
 
+Real-Time Messaging API vs. Events API
+-----------
+By default, this bot uses the Slack Real-Time Messaging API to listen and respond to messages. If your bot is running on a Heroku free-tier dyno, this will not work, as the API relies on persistent websockets. Instead, you may use the more traditional Events API, which uses HTTP requests that can wake up your dyno. Simply modify the proper values in `config.js` to enable this.
+
 Development
 -----------
 

--- a/config.js.example
+++ b/config.js.example
@@ -5,6 +5,15 @@ var rabbitmqresponder = require('./rabbitmq');
 var config = {
   slack_api_token: 'xxxx-xxxxxxxxx-xxx',
 
+  // Whether or not to use the Slack Real-Time Messaging API instead of the Events API.
+  use_rtm: true,
+
+  // If using the Events API, then configure the following:
+  events: {
+    port: 8888,
+    signing_secret: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+  },
+
   regexes: [
     { regex: /RND-[0-9]+/g, message: ['A: [0]', 'B: [0]'] },
     { regex: /TFS-[0-9]+/g, message: 'You mentioned [0]' },

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "main": "src/index.js",
   "dependencies": {
     "@slack/client": "^4.8.0",
+    "@slack/events-api": "^2.1.1",
     "jira-client": "^4.2.0",
     "node-schedule": "^1.2.0"
   },
   "devDependencies": {
-    "@slack/events-api": "^2.1.1",
     "chai": "^3.5.0",
     "coveralls": "^3.0.2",
     "eslint": "^2.13.1",

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ if (config.use_rtm) {
   client = createEventAdapter(config.events.signing_secret);
   client.start(config.events.port).then(() => {
     console.log('server listening on port ' + config.events.port);
+    config.build(config.events.port);
   });
 }
 


### PR DESCRIPTION
For users (like myself) who would like to run this bot on a Heroku free dyno, the RTM api does not suffice. So I have added support for the Events API as well. I have tested both the RTM and Events API configurations on my own Slack workspace, and they both work. Please have a look and tell me what you think!